### PR TITLE
Hls playlist check

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -216,7 +216,7 @@ update_history() {
 download() {
     case $1 in
         *m3u8*) ffmpeg -loglevel error -stats -i "$1" -c copy "$download_dir/$2.mp4" ;;
-        *) if curl -s "$1" | grep -q '^#EXTM3U'; then
+        *) if curl -s -m 5 "$1" | grep -q '^#EXTM3U'; then
         ffmpeg -loglevel error -stats -i "$1" -c copy "$download_dir/$2.mp4"
     else
         aria2c --check-certificate=false --continue --summary-interval=0 -x 16 -s 16 "$1" --dir="$download_dir" -o "$2.mp4" --download-result=hide

--- a/ani-cli
+++ b/ani-cli
@@ -216,7 +216,11 @@ update_history() {
 download() {
     case $1 in
         *m3u8*) ffmpeg -loglevel error -stats -i "$1" -c copy "$download_dir/$2.mp4" ;;
-        *) aria2c --check-certificate=false --continue --summary-interval=0 -x 16 -s 16 "$1" --dir="$download_dir" -o "$2.mp4" --download-result=hide ;;
+        *) if curl -s "$1" | grep -q '^#EXTM3U'; then
+        ffmpeg -loglevel error -stats -i "$1" -c copy "$download_dir/$2.mp4"
+    else
+        aria2c --check-certificate=false --continue --summary-interval=0 -x 16 -s 16 "$1" --dir="$download_dir" -o "$2.mp4" --download-result=hide
+  fi ;;
     esac
 }
 


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Documentation update

## Description

*ramble here*

## Checklist

- [x] any anime playing
- [x] bumped version
---
- [x] next, prev and replay work
- [x] `-c` history and continue work
- [x] `-d` downloads work
- [x] `-s` syncplay works
- [x] `-q` quality works
- [x] `-v` vlc works
- [x] `-e` select episode works
- [x] `-S` select index works
- [x] `-r` range selection works
- [x] `--dub` both work
- [x] all providers return links (not necessarily on a single anime, use debug mode to confirm)
---
- [x] `-h` help info is up to date
- [x] Readme is up to date
- [x] Man page is up to date

## Additional Testcases

- The safe bet: One Piece
- Episode 0: Saenai Heroine no Sodatekata ♭
- Unicode: Saenai Heroine no Sodatekata ♭
- Non-whole episodes: Tensei shitara slime datta ken (ep. 24.5, ep. 24.9)
